### PR TITLE
Update enable-modsecurity.md

### DIFF
--- a/docs/zh-cn/practice/enable-modsecurity.md
+++ b/docs/zh-cn/practice/enable-modsecurity.md
@@ -34,7 +34,7 @@ cp -r coreruleset/rules /etc/nginx/rules/modsecurity/owasp
 1. 编辑 `/etc/nginx/rules/modsecurity/modsecurity.conf`，将 `SecRuleEngine DetectionOnly` 修改为 `SecRuleEngine on`。
 2. 编辑 `/etc/nginx/rules/modsecurity/modsecurity.conf`，在文件末尾追加下列内容。
     ```
-    Include /usr/local/src/ngx_waf/assets/rules/crs-setup.conf
+    Include /etc/nginx/rules/modsecurity/crs-setup.conf
     Include /etc/nginx/rules/modsecurity/owasp/*.conf
     ```
 


### PR DESCRIPTION
原来 include 了一个不存在的文件，会导致nginx启动后无法访问，提示 “copy  crs-setup.conf.example template to crs-setup.conf”。修改后功能正常。